### PR TITLE
Change to cite definition

### DIFF
--- a/backend/refill/formatters/citetemplate.py
+++ b/backend/refill/formatters/citetemplate.py
@@ -8,7 +8,7 @@ class CiteTemplate(Formatter):
     ORDER = [
         'url',
         'archiveurl',
-        'deadurl',
+        'url-status',
         'title',
         'authors',
         'editors',
@@ -79,9 +79,9 @@ class CiteTemplate(Formatter):
     def _fragment_accessdate(self, template, citation):
         self._fragment_date(template, citation, field='accessdate')
 
-    def _fragment_deadurl(self, template, citation):
+    def _fragment_url-status(self, template, citation):
         if 'archiveurl' in citation:
-            template.add('deadurl', 'y')
+            template.add('url-status', 'dead')
 
     def _fragment_authors(self, template, citation, field='authors'):
         para = 'editor' if field == 'editors' else 'author'

--- a/backend/refill/models/citation.py
+++ b/backend/refill/models/citation.py
@@ -17,7 +17,7 @@ class Citation:
         'website': str,
         'archiveurl': str,
         'archivedate': date,
-        'deadurl': bool,
+        'url-status': str,
         'via': str,
         'journal': str,
         'volume': str,


### PR DESCRIPTION
Hello, there has been a change to the cite templates on wikipedia. The parameter deadurl has been replaced by url-status. The values for this being 'dead' or 'live'.

This modification is to implement this change but is untested as I cannot workout how to set-up for testing.