### PR TITLE
Copy all files in "github.com/refill-ng/refill-labsconf" repo to folder called "labs-config"

### DIFF
--- a/labs-config/README.md
+++ b/labs-config/README.md
@@ -1,0 +1,8 @@
+# Labs-specific configurations for reFill
+This repository holds the configurations used on the official reFill instance on Tool Labs. Changes to this repository are automatically applied to the actual configuration files. Pull requests are welcome.
+
+WARNING: If you are editing the files on Tool Labs directly, your changes will be overwritten when the source GitHub repository is pushed to. Please commit your changes to the GitHub repository instead.
+
+## FAQ
+### How are the files used?
+These configurations are applied with `require_once` in the corresponding `config.php` files.

--- a/labs-config/banners.php
+++ b/labs-config/banners.php
@@ -1,0 +1,15 @@
+<?php
+// Common banners
+// TODO: I18N
+
+// IE warning
+if ( false !== strpos( $_SERVER['HTTP_USER_AGENT'], "MSIE" ) || false !== strpos( $_SERVER['HTTP_USER_AGENT'], "Edge/12" ) || !empty( $_GET['forceiewarning'] ) ) {
+	$banners[] = "<div class='alert alert-danger'>Use Internet Explorer or Microsoft Edge at your own risk. Due to the XSS filter employed on those browsers, you may experience strange character replacements.</div>";
+}
+
+$banners[] = "<div class='alert alert-info'>"
+		. "<h4>reFill has new maintainers!</h4>"
+		. "<p>Led by <a href='https://en.wikipedia.org/wiki/User:Curb_Safe_Charmer'>User:Curb Safe Charmer</a> and <a href='https://en.wikipedia.org/wiki/User:TheresNoTime'>User:TheresNoTime</a>, a number of new maintainers are now working on reFill.</p>"
+		. "<p>Please bear with us as we work to update the tool, and feel free to <a href='https://phabricator.wikimedia.org/tag/tool-refill/'>report any bugs</a> you find.</p>"
+		. "</div>";
+

--- a/labs-config/citoid.php
+++ b/labs-config/citoid.php
@@ -1,0 +1,9 @@
+<?php
+// Configuations for the Citoid test instance
+require_once __DIR__ . "/test.php";
+
+// Use CitoidLinkHandler
+$config['linkhandlers'] = array( "CitoidLinkHandler" );
+
+// Banner
+$banners[] = "<div class='alert alert-info'>This instance of reFill is powered by <a href='https://mediawiki.org/wiki/Citoid'>Citoid</a>.</div>";

--- a/labs-config/common.php
+++ b/labs-config/common.php
@@ -1,0 +1,84 @@
+<?php
+// Common configuations
+
+$config['wikiprovider'] = "WikimediaWikiProvider";
+
+// Supported wikis
+$config['wm-defaultproject'] = "wikipedia";
+$config['wm-projects'] = array(
+	'wikipedia' => array(
+		'default' => 'en',
+		'api' => 'https://%id%.wikipedia.org/w/api.php',
+		'indexphp' => 'https://%id%.wikipedia.org/w/index.php',
+		'wikis' => array(
+			'en', 'sv', 'nl', 'de', 'fr', 'war', 'ceb', 'ru', 'it', 'es', 'vi', 'pl', 'simple', 'zh', 'ja', 'ro', 'bn', 'pt', 'af', 'el', 'ta', 'id', 'sco', 'ar', 'cs',
+			'simple' => array( // override language code
+				'language' => 'en'
+			)
+		)
+	),
+	'wikimedia' => array(
+		'default' => 'meta',
+		'language' => 'en', // the default language for the project
+		'api' => 'https://%id%.wikimedia.org/w/api.php',
+		'indexphp' => 'https://%id%.wikimedia.org/w/index.php',
+		'wikis' => array( 'meta', 'commons' )
+	)
+);
+
+// Link handlers
+$config['linkhandlers'] = array(
+	array(
+		"regex" => "/^https?\:\/\/archive\.(is|fo|li|today)/",
+		"handler" => "StandaloneLinkHandler"
+	),
+	array(
+		"regex" => "/^http\:\/\/www\.nytimes\.com/",
+		"handler" => "NewYorkTimesLinkHandler"
+	),
+	"CitoidLinkHandler",
+);
+$config['parserchain'] = array(
+	"CitoidMetadataParser",
+	"ArchiveIsUrlFixerMetadataParser",
+	"NewYorkTimesMetadataParser",
+);
+
+// Maximum execution time, in seconds
+$config['maxtime'] = 600;
+
+// Insert the domain name as |work= by default
+// (Disabled per suggestion at https://github.com/zhaofengli/refill/issues/12 - Let's be more conservative, alright?)
+// $config['options']['usedomainaswork']['default'] = true;
+
+// Blacklist WebCitation
+$config['blacklist'][] = "\bwebcitation.org\b";
+
+// Blacklist ProQuest
+$config['blacklist'][] = "\bproquest.com\b";
+
+// Banners
+$banners = array();
+
+// Footer link to Tool Labs
+function rlFooter() {
+	global $I18N;
+	return '<li><a href="https://wikitech.wikimedia.org/wiki/Portal:Toolforge"><img style="height: 20px; margin-right: 5px;" src="https://refill.toolforge.org/favicon.ico"/>' . $I18N->msg( "wmflabs-poweredby" ) . '</a></li>';
+}
+
+function rlBanner() {
+	global $banners, $bannerCallbacks;
+	$banner = implode( "", $banners );
+	//foreach ( $bannerCallbacks as $callback ) {
+	//	$banner .= call_user_func( $callback );
+	//}
+	return $banner;
+	return implode( "", $banners );
+}
+
+function rlBannerCallback( $callback ) {
+	global $bannerCallbacks;
+	$bannerCallbacks[] = $callback;
+}
+
+require_once __DIR__ . "/banners.php";

--- a/labs-config/stable.php
+++ b/labs-config/stable.php
@@ -1,0 +1,6 @@
+<?php
+// Configuations for the stable instance
+require_once __DIR__ . "/common.php";
+
+// Commit ID in default edit summary
+$config['summaryextra'] = " (" . substr( file_get_contents( ".git/refs/heads/labs-stable" ), 0, 7 ) . ")";

--- a/labs-config/test.php
+++ b/labs-config/test.php
@@ -1,0 +1,24 @@
+<?php
+// Configuations for the test instance
+require_once __DIR__ . "/common.php";
+
+// Report all errors
+error_reporting( E_ALL );
+
+// Experimental wikis
+$config['wm-projects']['wikipedia']['wikis'] = array_merge(
+	$config['wm-projects']['wikipedia']['wikis'],
+	array( "bh", "te", "kn", "bn", "hi", "gu", "gom", "ml", "or", "pa", "ta", "tcy", "sr" )
+);
+
+// Commit ID in default edit summary
+$config['summaryextra'] = " (" . substr( file_get_contents( ".git/refs/heads/master" ), 0, 7 ) . ")";
+
+// Test version banners
+rlBannerCallback( function() {
+	global $I18N, $app;
+	return "<div class='alert alert-info'>"
+	        . $I18N->msg( "wmflabs-thankyoutest", array( "variables" => array( $I18N->msg( "appname" ) ) ) ) . "<br>"
+	        . $I18N->msg( "wmflabs-latestcommit", array( "variables" => array( htmlspecialchars( `git log -1 --oneline` ) ) ) )
+	        . "</div>";
+} );


### PR DESCRIPTION
This project has a problem with duplication. It has 2 git branches, 2 issue trackers, and 2 repositories. This patch begins consolidating everything into one repository and one branch.

- Copy all files in "github.com/refill-ng/refill-labsconf" repo to folder called "labs-config"

We should probably delete the https://github.com/refill-ng/refill-labsconf repo (set it to private) after this patch is merged, to prevent accidentally merging to the wrong repo.

The repo's readme claims that merging code to it automatically updates "Tool Labs" (I assume they mean Toolforge?), but I don't see a .github folder, therefore I don't think it has a working continuous deployment.

Bug: https://phabricator.wikimedia.org/T340503