### PR TITLE
convert from vue 2 to vue 3

### DIFF
--- a/refill.toolforge.org/versions/stable/web/ng/package-lock.json
+++ b/refill.toolforge.org/versions/stable/web/ng/package-lock.json
@@ -16,14 +16,13 @@
         "localforage": "^1.10.0",
         "oboe": "^2.1.5",
         "urijs": "^1.19.11",
-        "vue": "^2.6.14",
+        "vue": "^3.2.47",
         "vue-banana-i18n": "^2.3.0",
         "vue-config": "^1.0.0",
-        "vue-loader": "^15.9.6",
-        "vue-loader-plugin": "^1.3.0",
+        "vue-loader": "^17.0.0",
         "vue-resource": "^1.5.3",
-        "vue-router": "^3.5.4",
-        "vuetify": "^2.6.6"
+        "vue-router": "^4.2.2",
+        "vuetify": "^3.1.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.18.0",
@@ -34,10 +33,9 @@
         "eslint-plugin-vue": "^9.0.1",
         "html-webpack-plugin": "^5.5.0",
         "laravel-mix": "^6.0.43",
-        "sass": "^1.52.1",
+        "sass": "^1.66.1",
         "sass-loader": "^13.0.0",
         "style-loader": "^3.3.1",
-        "vue-template-compiler": "^2.6.14",
         "webpack": "^5.76.0",
         "webpack-cli": "^4.9.2",
         "webpack-dev-server": "^4.9.0"
@@ -2713,63 +2711,55 @@
         "@vue/shared": "3.5.32"
       }
     },
-    "node_modules/@vue/component-compiler-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-3.3.0.tgz",
-      "integrity": "sha512-97sfH2mYNU+2PzGrmK2haqffDpVASuib9/w2/noxiFi31Z54hW+q3izKQXXQZSNhtiUpAI36uSuYepeBe4wpHQ==",
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.32.tgz",
+      "integrity": "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==",
       "license": "MIT",
       "dependencies": {
-        "consolidate": "^0.15.1",
-        "hash-sum": "^1.0.2",
-        "lru-cache": "^4.1.2",
-        "merge-source-map": "^1.1.0",
-        "postcss": "^7.0.36",
-        "postcss-selector-parser": "^6.0.2",
-        "source-map": "~0.6.1",
-        "vue-template-es2015-compiler": "^1.9.0"
-      },
-      "optionalDependencies": {
-        "prettier": "^1.18.2 || ^2.0.0"
+        "@vue/shared": "3.5.32"
       }
     },
-    "node_modules/@vue/component-compiler-utils/node_modules/lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "license": "ISC",
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "node_modules/@vue/component-compiler-utils/node_modules/picocolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-      "license": "ISC"
-    },
-    "node_modules/@vue/component-compiler-utils/node_modules/postcss": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.32.tgz",
+      "integrity": "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==",
       "license": "MIT",
       "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
+        "@vue/reactivity": "3.5.32",
+        "@vue/shared": "3.5.32"
       }
     },
-    "node_modules/@vue/component-compiler-utils/node_modules/yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-      "license": "ISC"
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz",
+      "integrity": "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.32",
+        "@vue/runtime-core": "3.5.32",
+        "@vue/shared": "3.5.32",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.32.tgz",
+      "integrity": "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.32",
+        "@vue/shared": "3.5.32"
+      },
+      "peerDependencies": {
+        "vue": "3.5.32"
+      }
     },
     "node_modules/@vue/shared": {
       "version": "3.5.32",
@@ -3125,7 +3115,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3406,6 +3395,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -3423,12 +3413,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "license": "MIT"
     },
     "node_modules/bn.js": {
       "version": "5.2.3",
@@ -3840,7 +3824,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4007,7 +3990,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4020,7 +4002,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colord": {
@@ -4155,19 +4136,6 @@
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
       "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
       "dev": true
-    },
-    "node_modules/consolidate": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.15.1.tgz",
-      "integrity": "sha512-DW46nrsMJgy9kqAbPt5rKaCr7uFtpo4mSUvLHIUbJEjm0vo+aY5QLwBUq3FK4tRnJr/X0Psc0C4jf/h+HtXSMw==",
-      "deprecated": "Please upgrade to consolidate v1.0.0+ as it has been modernized with several long-awaited fixes implemented. Maintenance is supported by Forward Email at https://forwardemail.net ; follow/watch https://github.com/ladjs/consolidate for updates and release changelog",
-      "license": "MIT",
-      "dependencies": {
-        "bluebird": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
     },
     "node_modules/constants-browserify": {
       "version": "1.0.0",
@@ -4407,6 +4375,7 @@
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.11.0.tgz",
       "integrity": "sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "icss-utils": "^5.1.0",
@@ -4442,6 +4411,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4514,6 +4484,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -4618,13 +4589,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
-    },
-    "node_modules/de-indent": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -5077,6 +5041,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -6249,6 +6214,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
       "integrity": "sha512-fUs4B4L+mlt8/XAtSOGMUO1TXmAelItBPtJG7CyHJfYTdDjwisntGO2JQz7oUsatOY9o68+57eziUVNw/mRHmA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/hash.js": {
@@ -6651,6 +6617,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^10 || ^12 || >= 14"
@@ -7666,15 +7633,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/merge-source-map": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
-      "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "^0.6.1"
-      }
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -7861,6 +7819,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8869,6 +8828,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
       "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^10 || ^12 || >= 14"
@@ -8881,6 +8841,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.2.0.tgz",
       "integrity": "sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "icss-utils": "^5.0.0",
@@ -8898,6 +8859,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -8911,6 +8873,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
       "integrity": "sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "postcss-selector-parser": "^7.0.0"
@@ -8926,6 +8889,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -8939,6 +8903,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
       "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "icss-utils": "^5.0.0"
@@ -9147,6 +9112,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -9193,6 +9159,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -9203,22 +9170,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-error": {
@@ -9282,12 +9233,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
-      "license": "ISC"
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
@@ -10577,7 +10522,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -11056,6 +11000,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/util/node_modules/inherits": {
@@ -11110,14 +11055,24 @@
       "license": "MIT"
     },
     "node_modules/vue": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.16.tgz",
-      "integrity": "sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==",
-      "deprecated": "Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
+      "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-sfc": "2.7.16",
-        "csstype": "^3.1.0"
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/compiler-sfc": "3.5.32",
+        "@vue/runtime-dom": "3.5.32",
+        "@vue/server-renderer": "3.5.32",
+        "@vue/shared": "3.5.32"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/vue-banana-i18n": {
@@ -11173,71 +11128,33 @@
         "node": ">=10"
       }
     },
-    "node_modules/vue-hot-reload-api": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
-      "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==",
-      "license": "MIT"
-    },
     "node_modules/vue-loader": {
-      "version": "15.11.1",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.11.1.tgz",
-      "integrity": "sha512-0iw4VchYLePqJfJu9s62ACWUXeSqM30SQqlIftbYWM3C+jpPcEHKSPUZBLjSF9au4HTHQ/naF6OGnO3Q/qGR3Q==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-17.4.2.tgz",
+      "integrity": "sha512-yTKOA4R/VN4jqjw4y5HrynFL8AK0Z3/Jt7eOJXEitsm0GMRHDBjCfCiuTiLP7OESvsZYo2pATCWhDqxC5ZrM6w==",
       "license": "MIT",
       "dependencies": {
-        "@vue/component-compiler-utils": "^3.1.0",
-        "hash-sum": "^1.0.2",
-        "loader-utils": "^1.1.0",
-        "vue-hot-reload-api": "^2.3.0",
-        "vue-style-loader": "^4.1.0"
+        "chalk": "^4.1.0",
+        "hash-sum": "^2.0.0",
+        "watchpack": "^2.4.0"
       },
       "peerDependencies": {
-        "css-loader": "*",
-        "webpack": "^3.0.0 || ^4.1.0 || ^5.0.0-0"
+        "webpack": "^4.1.0 || ^5.0.0-0"
       },
       "peerDependenciesMeta": {
-        "cache-loader": {
+        "@vue/compiler-sfc": {
           "optional": true
         },
-        "prettier": {
-          "optional": true
-        },
-        "vue-template-compiler": {
+        "vue": {
           "optional": true
         }
       }
     },
-    "node_modules/vue-loader-plugin": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/vue-loader-plugin/-/vue-loader-plugin-1.3.0.tgz",
-      "integrity": "sha512-kzWyVB81zHnkv41tAC2nQtRKDWEA3od791FWjV/JOg9TSaop6Uvt92VWIPQQ84FK2UQYP4Ah99vAaVZXSnIgYA==",
-      "license": "ISC"
-    },
-    "node_modules/vue-loader/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/vue-loader/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
+    "node_modules/vue-loader/node_modules/hash-sum": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
+      "license": "MIT"
     },
     "node_modules/vue-resource": {
       "version": "1.5.3",
@@ -11249,15 +11166,25 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.6.5.tgz",
-      "integrity": "sha512-VYXZQLtjuvKxxcshuRAwjHnciqZVoXAjTjcqBTz4rKc8qih9g9pI3hbDjmqXaHdgL3v8pV6P8Z335XvHzESxLQ==",
-      "license": "MIT"
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
     },
     "node_modules/vue-style-loader": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.3.tgz",
       "integrity": "sha512-sFuh0xfbtpRlKfm39ss/ikqs9AbKCoXZBpHeVZ8Tx650o0k0q/YCM7FRvigtxpACezfq6af+a7JeqVTWvncqDg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hash-sum": "^1.0.2",
@@ -11268,6 +11195,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
       "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.0"
@@ -11280,6 +11208,7 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
       "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "big.js": "^5.2.2",
@@ -11290,47 +11219,31 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/vue-template-compiler": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
-      "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "de-indent": "^1.0.2",
-        "he": "^1.2.0"
-      }
-    },
-    "node_modules/vue-template-es2015-compiler": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
-      "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
-      "license": "MIT"
-    },
-    "node_modules/vue/node_modules/@vue/compiler-sfc": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz",
-      "integrity": "sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==",
-      "dependencies": {
-        "@babel/parser": "^7.23.5",
-        "postcss": "^8.4.14",
-        "source-map": "^0.6.1"
-      },
-      "optionalDependencies": {
-        "prettier": "^1.18.2 || ^2.0.0"
-      }
-    },
     "node_modules/vuetify": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.7.2.tgz",
-      "integrity": "sha512-qr04ww7uzAPQbpk751x4fSdjsJ+zREzjQ/rBlcQGuWS6MIMFMXcXcwvp4+/tnGsULZxPMWfQ0kmZmg5Yc/XzgQ==",
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.12.5.tgz",
+      "integrity": "sha512-Gk3eDIiBXpv+QjMTYmXXk/uvpqaSNAgprcV/Og0btBUx4saLN7AUmqUi34hRmBqu2tpype2GVvg2yxJUqP2mdg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/johnleider"
       },
       "peerDependencies": {
-        "vue": "^2.6.4"
+        "typescript": ">=4.7",
+        "vite-plugin-vuetify": ">=2.1.0",
+        "vue": "^3.5.0",
+        "webpack-plugin-vuetify": ">=3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vite-plugin-vuetify": {
+          "optional": true
+        },
+        "webpack-plugin-vuetify": {
+          "optional": true
+        }
       }
     },
     "node_modules/watchpack": {

--- a/refill.toolforge.org/versions/stable/web/ng/package.json
+++ b/refill.toolforge.org/versions/stable/web/ng/package.json
@@ -18,14 +18,13 @@
     "localforage": "^1.10.0",
     "oboe": "^2.1.5",
     "urijs": "^1.19.11",
-    "vue": "^2.6.14",
+    "vue": "^3.2.47",
     "vue-banana-i18n": "^2.3.0",
     "vue-config": "^1.0.0",
-    "vue-loader": "^15.9.6",
-    "vue-loader-plugin": "^1.3.0",
+    "vue-loader": "^17.0.0",
     "vue-resource": "^1.5.3",
-    "vue-router": "^3.5.4",
-    "vuetify": "^2.6.6"
+    "vue-router": "^4.2.2",
+    "vuetify": "^3.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.18.0",
@@ -36,10 +35,10 @@
     "eslint-plugin-vue": "^9.0.1",
     "html-webpack-plugin": "^5.5.0",
     "laravel-mix": "^6.0.43",
-    "sass": "^1.52.1",
+    "sass": "^1.66.1",
     "sass-loader": "^13.0.0",
     "style-loader": "^3.3.1",
-    "vue-template-compiler": "^2.6.14",
+    
     "webpack": "^5.76.0",
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.9.0"

--- a/refill.toolforge.org/versions/stable/web/ng/src/App.vue
+++ b/refill.toolforge.org/versions/stable/web/ng/src/App.vue
@@ -1,22 +1,22 @@
 <template>
   <div id="app">
     <v-app>
-      <v-toolbar color="primary" dark>
-        <v-toolbar-title><a :href="$config.publicPath">{{ msg('appname') }}</a></v-toolbar-title>
+      <v-app-bar color="primary" dark>
+        <div class="v-toolbar__title"><a :href="$config.publicPath">{{ msg('appname') }}</a></div>
         <v-spacer></v-spacer>
 
-        <v-toolbar-items class="hidden-sm-and-down">
+        <div class="v-toolbar-items hidden-sm-and-down">
           <v-btn icon href="https://en.wikipedia.org/wiki/Wikipedia:ReFill">
-            <v-icon>help</v-icon>
+            <span class="material-icons">help</span>
           </v-btn>
           <v-btn icon href="https://en.wikipedia.org/wiki/Wikipedia_talk:ReFill">
-            <v-icon>bug_report</v-icon>
+            <span class="material-icons">bug_report</span>
           </v-btn>
           <v-btn icon href="https://github.com/curbsafecharmer/refill">
-            <v-icon>code</v-icon>
+            <span class="material-icons">code</span>
           </v-btn>
-        </v-toolbar-items>
-      </v-toolbar>
+        </div>
+      </v-app-bar>
 
       <v-container fluid fill-height>
         <transition name="slide">

--- a/refill.toolforge.org/versions/stable/web/ng/src/components/Change.vue
+++ b/refill.toolforge.org/versions/stable/web/ng/src/components/Change.vue
@@ -1,15 +1,15 @@
 <template>
-  <v-layout row wrap>
-    <v-flex xs5>
+  <v-row class="flex-wrap">
+    <v-col cols="5">
       <span class="wikicode">{{ change.old }}</span>
-    </v-flex>
-    <v-flex xs2>
+    </v-col>
+    <v-col cols="2">
       <span class="arrow">➡</span>
-    </v-flex>
-    <v-flex xs5>
+    </v-col>
+    <v-col cols="5">
       <span class="wikicode">{{ change.new }}</span>
-    </v-flex>
-  </v-layout>
+    </v-col>
+  </v-row>
 </template>
 <script>
 export default {

--- a/refill.toolforge.org/versions/stable/web/ng/src/components/ChangeDetails.vue
+++ b/refill.toolforge.org/versions/stable/web/ng/src/components/ChangeDetails.vue
@@ -4,9 +4,9 @@
     width="800px"
   >
     <v-card v-if="dialog">
-      <v-toolbar color="primary" dark>
-        {{ msg('report') }}
-      </v-toolbar>
+      <v-app-bar color="primary" dark>
+        <div class="v-toolbar__title">{{ msg('report') }}</div>
+      </v-app-bar>
       <div class="shade">
         <Change :change="changes[id]"/>
       </div>

--- a/refill.toolforge.org/versions/stable/web/ng/src/components/ErrorDetails.vue
+++ b/refill.toolforge.org/versions/stable/web/ng/src/components/ErrorDetails.vue
@@ -4,9 +4,9 @@
     width="800px"
   >
     <v-card v-if="dialog">
-      <v-toolbar color="primary" dark>
-        {{ msg('error-details') }}
-      </v-toolbar>
+      <v-app-bar color="primary" dark>
+        <div class="v-toolbar__title">{{ msg('error-details') }}</div>
+      </v-app-bar>
       <div class="shade">
         {{ msg('error-type-' + errors[id].type) }}
       </div>

--- a/refill.toolforge.org/versions/stable/web/ng/src/components/PreferencesEditor.vue
+++ b/refill.toolforge.org/versions/stable/web/ng/src/components/PreferencesEditor.vue
@@ -4,9 +4,9 @@
     width="500"
   >
     <v-card> 
-      <v-toolbar color="primary" dark>
-        {{ msg('preferences') }}
-      </v-toolbar>
+      <v-app-bar color="primary" dark>
+        <div class="v-toolbar__title">{{ msg('preferences') }}</div>
+      </v-app-bar>
       <v-card-text v-if="!loading"> 
         <v-checkbox
           :label="msg('preferences-addAccessDates')"
@@ -16,12 +16,13 @@
           :label="msg('preferences-dateFormatEn')"
           :items="enDateFormats"
           v-model="preferences.dateFormat.en"
+          variant="outlined"
         ></v-select>
       </v-card-text>
       <v-progress-linear v-else :indeterminate="true"></v-progress-linear>
 
       <v-card-actions>
-        <v-btn flat @click="save">{{ msg('preferences-save') }}</v-btn>
+        <v-btn variant="text" @click="save">{{ msg('preferences-save') }}</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/refill.toolforge.org/versions/stable/web/ng/src/main.js
+++ b/refill.toolforge.org/versions/stable/web/ng/src/main.js
@@ -1,20 +1,19 @@
 /* eslint-disable no-undef */
 import "core-js/stable";
 
-import Vue from 'vue';
+import { createApp } from 'vue';
 
 // == Configurations ==
 import VueConfig from 'vue-config';
-Vue.use(VueConfig, staticConfig);
 
 // == Imports ==
-import VueRouter from 'vue-router';
-Vue.use(VueRouter);
+import { createRouter, createWebHistory } from 'vue-router';
 
-import Vuetify from 'vuetify';
-import 'vuetify/dist/vuetify.min.css';
+import { createVuetify } from 'vuetify';
+import 'vuetify/styles';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
 import './fonts/material-icons.css';
-Vue.use(Vuetify);
 /*
 Vue.material.registerTheme('default', {
   primary: 'blue',
@@ -24,9 +23,6 @@ Vue.material.registerTheme('default', {
 });
 */
 
-import VueResource from 'vue-resource';
-Vue.use(VueResource);
-
 // == I18N ==
 import Banana from 'banana-i18n/dist/cjs/banana-i18n.cjs';
 const banana = new Banana('en');
@@ -35,13 +31,7 @@ let req = require.context('../../../../../../messages', false, /\.json$/);
 req.keys().forEach(function(key){
   banana.load(req(key), key.replace(/\.[^/.]+$/, '').slice(2));
 });
-Vue.mixin({
-  methods: {
-    msg(...args) {
-      return banana.i18n(...args);
-    }
-  }
-});
+// We'll install a global mixin on the app instance below so `msg()` is available in components.
 
 import Cookies from 'js-cookie';
 let ts = Cookies.get('TsIntuition_userlang');
@@ -60,19 +50,46 @@ const routes = [
   { path: '/', component: Index },
   { path: '/result/:taskName/:taskId', component: Result },
   { path: '/result.php', component: LegacyBridge },
-  { path: '*', component: PageNotFound }
+  { path: '/:pathMatch(.*)*', component: PageNotFound }
 ];
 
-const router = new VueRouter({
-  routes: routes,
-  mode: 'history',
-  base: staticConfig.publicPath
+const router = createRouter({
+  history: createWebHistory(staticConfig.publicPath),
+  routes: routes
 });
 
-window.app = new Vue({
-  el: '#app',
-  vuetify : new Vuetify(),
-  render: h => h(App),
-  router: router
+const app = createApp(App);
+app.use(VueConfig, staticConfig);
+app.use(router);
+const vuetify = createVuetify({
+  components,
+  directives,
+  theme: {
+    defaultTheme: 'light',
+    themes: {
+      light: {
+        colors: {
+          primary: '#1976D2',
+          secondary: '#424242',
+          accent: '#82B1FF',
+          error: '#FF5252',
+          info: '#2196F3',
+          success: '#4CAF50',
+          warning: '#FB8C00'
+        }
+      }
+    }
+  }
 });
+app.use(vuetify);
+app.mixin({
+  methods: {
+    msg(...args) {
+      return banana.i18n(...args);
+    }
+  }
+});
+
+// expose globally like before
+window.app = app.mount('#app');
 

--- a/refill.toolforge.org/versions/stable/web/ng/src/pages/Index.vue
+++ b/refill.toolforge.org/versions/stable/web/ng/src/pages/Index.vue
@@ -1,16 +1,16 @@
 /* eslint-disable vue/multi-word-component-names */
 <template>
-  <v-flex md8 offset-md2 lg6 offset-lg3>
-    <v-container fluid grid-list-lg class="mcontainer">
-      <v-layout row wrap>
-        <v-flex xs12>
+  <v-col md="8" offset-md="2" lg="6" offset-lg="3">
+    <v-container fluid class="mcontainer">
+      <v-row class="flex-wrap">
+        <v-col cols="12">
           <h1>{{ msg('appname') }}</h1>
           <h2 class="tagline">{{ msg('tagline') }}</h2>
-        </v-flex>
-      </v-layout>
+        </v-col>
+      </v-row>
 
-      <v-layout row wrap>
-        <v-flex xs12>
+      <v-row class="flex-wrap">
+        <v-col cols="12">
           <v-card>
             <v-card-text>
               <div class="wikipage-form">
@@ -20,20 +20,23 @@
                   placeholder=""
                   @keyup.enter="fixWikipage"
                   :label="msg('fixwikipage-page')"
+                  variant="outlined"
                 ></v-text-field>
                 <v-text-field
                   v-model="code"
                   class="code"
                   :label="msg('fixwikipage-code')"
+                  variant="outlined"
                 ></v-text-field>
                 <v-text-field
                   v-model="fam"
                   class="fam"
                   :label="msg('fixwikipage-fam')"
+                  variant="outlined"
                 ></v-text-field>
 
-                <v-btn large text outlined color="primary" icon @click="fixWikipage">
-                  <v-icon>arrow_forward</v-icon>
+                <v-btn size="large" variant="outlined" color="primary" icon @click="fixWikipage">
+                  <span class="material-icons">arrow_forward</span>
                 </v-btn>
               </div>
               <v-slide-y-transition>
@@ -42,21 +45,22 @@
                     v-model="wikicode"
                     :label="msg('fixwikicode-wikicode')"
                     @focus="onWikicodeFocus"
+                    variant="outlined"
                   ></v-textarea>
                 </div>
               </v-slide-y-transition>
             </v-card-text>
           </v-card>
-          <v-btn text @click="useCustomWikicode = !useCustomWikicode">
-            <v-icon left>{{ useCustomWikicode ? 'remove' : 'add' }}</v-icon>
+          <v-btn variant="text" @click="useCustomWikicode = !useCustomWikicode">
+            <span class="material-icons left">{{ useCustomWikicode ? 'remove' : 'add' }}</span>
             {{ msg('wikicode-toggle') }}
           </v-btn>
-          <v-btn text @click="$refs.preferences.show()">
-            <v-icon left>settings</v-icon>
+          <v-btn variant="text" @click="$refs.preferences.show()">
+            <span class="material-icons left">settings</span>
             {{ msg('preferences-button') }}
           </v-btn>
-        </v-flex>
-      </v-layout>
+        </v-col>
+      </v-row>
     </v-container>
 
     <v-snackbar
@@ -66,7 +70,7 @@
       <span>{{ error }}</span>
     </v-snackbar>
     <PreferencesEditor ref="preferences"/>
-  </v-flex>
+  </v-col>
 </template>
 <script>
 import Utils from '../Utils';

--- a/refill.toolforge.org/versions/stable/web/ng/src/pages/LegacyBridge.vue
+++ b/refill.toolforge.org/versions/stable/web/ng/src/pages/LegacyBridge.vue
@@ -1,11 +1,11 @@
 <template>
-  <v-flex md8 offset-md2 lg6 offset-lg3 align-self-start>
+  <v-col md="8" offset-md="2" lg="6" offset-lg="3" class="align-self-start">
     <v-card>
       <v-card-text>
         {{ msg('legacybridge-submitting') }} {{ error }}
       </v-card-text>
     </v-card>
-  </v-flex>
+  </v-col>
 </template>
 <script>
 import Utils from '../Utils';

--- a/refill.toolforge.org/versions/stable/web/ng/src/pages/Result.vue
+++ b/refill.toolforge.org/versions/stable/web/ng/src/pages/Result.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-flex md8 offset-md2 lg6 offset-lg3 align-self-start>
+  <v-col md="8" offset-md="2" lg="6" offset-lg="3" class="align-self-start">
     <h1>{{ msg('result') }}</h1>
 
     <v-card class="progress-card">
@@ -10,12 +10,12 @@
             color="primary"
             v-if="!loaded || running"
           ></v-progress-circular>
-          <v-icon v-else-if="state == 'PENDING'">hourglass_empty</v-icon>
-          <v-icon v-else-if="state == 'SUCCESS'" class="successful">done</v-icon>
-          <v-icon v-else-if="state == 'FAILURE'" class="unsuccessful">error</v-icon>
-          <v-icon v-else-if="state == 'REVOKED'" class="unsuccessful">cancel</v-icon>
-          <v-icon v-else-if="state == 'BACKEND_ERROR'" class="unsuccessful">cloud_off</v-icon>
-          <v-icon v-else>help</v-icon>
+          <span v-else-if="state == 'PENDING'" class="material-icons">hourglass_empty</span>
+          <span v-else-if="state == 'SUCCESS'" class="material-icons successful">done</span>
+          <span v-else-if="state == 'FAILURE'" class="material-icons unsuccessful">error</span>
+          <span v-else-if="state == 'REVOKED'" class="material-icons unsuccessful">cancel</span>
+          <span v-else-if="state == 'BACKEND_ERROR'" class="material-icons unsuccessful">cloud_off</span>
+          <span v-else class="material-icons">help</span>
         </div>
         <div v-if="loaded" class="progress-wrapper">
           {{ msg('state-' + state) }}
@@ -36,7 +36,7 @@
       </div>
       <v-textarea
         v-model="wikicode"
-        outline
+        variant="outlined"
       ></v-textarea>
 
       <ChangeDetails ref="changeDialog" :changes="changes" :taskName="taskName" :taskId="taskId"/>
@@ -46,9 +46,9 @@
         <v-card-actions>
           <span class="tip">{{ msg('chancetoreview') }}</span>
           <v-spacer></v-spacer>
-          <v-btn color="primary" @click.native="savePage" :disabled="!wikiAction">{{ msg('previewandsave') }}</v-btn>
+          <v-btn color="primary" @click="savePage" :disabled="!wikiAction">{{ msg('previewandsave') }}</v-btn>
           <v-btn icon @click="showTaskInfo = !showTaskInfo">
-            <v-icon>keyboard_arrow_down</v-icon>
+            <span class="material-icons">keyboard_arrow_down</span>
           </v-btn>
         </v-card-actions>
         <v-slide-y-transition>
@@ -76,8 +76,7 @@
       <input type="hidden" name="wpWatchthis" value="n">
       <input type="hidden" name="wpUltimateParam" value="1">
     </form>
-    </div>
-  </v-flex>
+  </v-col>
 </template>
 <script>
 import oboe from 'oboe';

--- a/refill.toolforge.org/versions/stable/web/ng/webpack.config.js
+++ b/refill.toolforge.org/versions/stable/web/ng/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const VueLoaderPlugin = require('vue-loader-plugin');
+const { VueLoaderPlugin } = require('vue-loader');
 const config = require(`./config.${process.env.NODE_ENV}.js`);
 
 module.exports = {
@@ -23,7 +23,7 @@ module.exports = {
       'libs',
     ],
     alias: {
-      'vue$': 'vue/dist/vue.esm.js',
+      'vue$': 'vue/dist/vue.esm-bundler.js',
       'messages': path.resolve(__dirname, '../../../../../messages'),
     },
   },
@@ -35,7 +35,19 @@ module.exports = {
       },
       {
         test: /\.scss$/,
-        use: [ 'style-loader', 'css-loader', 'sass-loader' ],
+        use: [
+          'style-loader',
+          'css-loader',
+          {
+            loader: 'sass-loader',
+            options: {
+              implementation: require('sass'),
+              sassOptions: {
+                quietDeps: true
+              }
+            }
+          }
+        ],
       },
       {
         test: /\.vue$/,
@@ -45,8 +57,20 @@ module.exports = {
             // Since sass-loader (weirdly) has SCSS as its default parse mode, we map
             // the "scss" and "sass" values for the lang attribute to the right configs here.
             // other preprocessors should work out of the box, no loader config like this necessary.
-            scss: [ 'vue-style-loader', 'css-loader', 'sass-loader' ],
-            sass: [ 'vue-style-loader', 'css-loader', 'sass-loader?indentedSyntax' ],
+            scss: [ 'vue-style-loader', 'css-loader', {
+              loader: 'sass-loader',
+              options: {
+                implementation: require('sass'),
+                sassOptions: { quietDeps: true }
+              }
+            } ],
+            sass: [ 'vue-style-loader', 'css-loader', {
+              loader: 'sass-loader',
+              options: {
+                implementation: require('sass'),
+                sassOptions: { indentedSyntax: true, quietDeps: true }
+              }
+            } ],
           },
           // other vue-loader options go here
         },
@@ -66,6 +90,16 @@ module.exports = {
       ],
     },
   },
+  // Suppress deprecation warnings emitted by Dart Sass legacy JS API
+  ignoreWarnings: [
+    warning => {
+      try {
+        return typeof warning.message === 'string' && /The legacy JS API is deprecated/.test(warning.message);
+      } catch (e) {
+        return false;
+      }
+    }
+  ],
   performance: {
     hints: false,
   },


### PR DESCRIPTION
AI-generated. Renders, but has multiple issues:

- visual elements are in the wrong place or not styled properly (biggest problem)
- it couldn't figure out how to fix deprecation warnings, so it added code to suppress them instead
- console warning:
```
[Vue Router warn]: <router-view> can no longer be used directly inside <transition> or <keep-alive>.
Use slot props instead:

<router-view v-slot="{ Component }">
  <transition>
    <component :is="Component" />
  </transition>
</router-view>
```

Interestingly, all functionality works. You can type in a page, press the button, and refill talks to the API and does the wikitext transformation. Then you can click the button and get your on-wiki diff. Changing language using a cookie works too.

I am not going to merge this, but will save this as a draft in case the AI is on the right track / in case this gives useful ideas for a proper Vue 3 conversion later.

<img width="1916" height="445" alt="image" src="https://github.com/user-attachments/assets/ddbe1a1d-725d-4a23-a186-534c2de37430" />