### PR TITLE
Update utils.py

### DIFF
--- a/refill-api.toolforge.org/refill/backend/refill/utils/utils.py
+++ b/refill-api.toolforge.org/refill/backend/refill/utils/utils.py
@@ -1,7 +1,6 @@
 import re
 from datetime import date
 
-from babel.dates import format_date
 from mwparserfromhell.wikicode import Wikicode
 
 
@@ -63,4 +62,4 @@ class Utils:
             else:
                 return date.strftime(f).replace("%=d", str(date.day))
         else:
-            return format_date(date, locale=lang)
+            return f"{date.year}-{date.month:02}-{date.day:02}"


### PR DESCRIPTION
There's no correlation between babel.dates and a non-English Wikipedia's preffered date format. If the {{Cite web}} template uses ymd dates, the Lua script in that template can format the date with in local formatting prefference.

See [T352381](https://phabricator.wikimedia.org/T352381) and [T393124](https://phabricator.wikimedia.org/T393124)